### PR TITLE
Use reflection padding in the depth decoder

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+Augmentations = "201790e9-3802-4bf2-a4d2-ca8acc212efd"
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/Monodepth.jl
+++ b/src/Monodepth.jl
@@ -189,11 +189,11 @@ function train()
     dataset = Depth10k(image_dir, image_files; flip_augmentation)
     parameters = Params(;
         batch_size=2, target_size=dataset.resolution,
-        disparity_smoothness=1e-3, automasking=true)
+        disparity_smoothness=1e-3, automasking=false)
     max_scale, scale_levels = 5, collect(2:5)
     scales = [1.0 / 2.0^(max_scale - slevel) for slevel in scale_levels]
 
-    display(parameters); println()
+    println(parameters)
 
     # Transfer to the device.
     projections = device(precision(Project(;
@@ -208,12 +208,12 @@ function train()
         ssim, backprojections, projections, Ks, invKs,
         scales, dataset.source_ids, dataset.target_pos_id)
 
-    # encoder = ResidualNetwork(18; in_channels=3, classes=nothing)
-    # encoder_channels = collect(encoder.stages)
-    encoder = EffNet("efficientnet-b0"; include_head=false, in_channels=3)
-    encoder_channels = collect(encoder.stages_channels)
+    encoder = ResidualNetwork(18; in_channels=3, classes=nothing)
+    encoder_channels = collect(encoder.stages)
+    # encoder = EffNet("efficientnet-b0"; include_head=false, in_channels=3)
+    # encoder_channels = collect(encoder.stages_channels)
     depth_decoder = DepthDecoder(;encoder_channels, scale_levels)
-    pose_decoder = PoseDecoder(encoder_channels[end], 2, 1)
+    pose_decoder = PoseDecoder(encoder_channels[end])
     model = device(precision(Model(encoder, depth_decoder, pose_decoder)))
 
     θ = params(model)

--- a/src/dtk.jl
+++ b/src/dtk.jl
@@ -6,23 +6,29 @@ struct Depth10k
 
     source_ids::Vector{Int64}
     target_pos_id::Int64
+
+    flip_augmentation::Union{Augmentations.FlipX, Nothing}
 end
-function Depth10k(image_dir, image_files)
+function Depth10k(image_dir, image_files; flip_augmentation = nothing)
     focal = 2648.0 / 4.63461538462
     width, height = 416, 128
     K = SMatrix{3, 3, Float64, 9}(
         focal, 0, 0,
         0, focal, 0,
         width / 2.0, height / 2.0, 1)
-    Depth10k(K, image_dir, image_files, (width, height), [1, 3], 2)
+    Depth10k(K, image_dir, image_files, (width, height), [1, 3], 2, flip_augmentation)
 end
 
 Base.length(d::Depth10k) = length(d.files)
 function Base.getindex(d::Depth10k, i)
     width = d.resolution[1]
-    frames = joinpath(d.dir, d.files[i]) |> load |> channelview .|> Float32
-    frames = permutedims(frames, (3, 2, 1))
-    cat([frames[(width * j + 1):(width * (j + 1)), :, :] for j in 0:2]...; dims=4)
+    frames = joinpath(d.dir, d.files[i]) |> load
+
+    frames = [frames[:, (width * j + 1):(width * (j + 1))] for j in 0:2]
+    if d.flip_augmentation ≢ nothing
+        frames = d.flip_augmentation(frames)
+    end
+    permutedims(cat(channelview.(frames)...; dims=4), (3, 2, 1, 4))
 end
 
 @inline DataLoaders.nobs(d::Depth10k) = length(d.files)

--- a/src/pose_decoder.jl
+++ b/src/pose_decoder.jl
@@ -1,25 +1,22 @@
-struct PoseDecoder{S, P1, P2, P3}
+struct PoseDecoder{S, P}
     squeezer::S
-    p1::P1
-    p2::P2
-    p3::P3
-    n_predictions::Int64
+    pose::P
 end
 Flux.@functor PoseDecoder
 
-function PoseDecoder(encoder_out_channels, n_input_features::Int, n_predictions::Int)
+function PoseDecoder(encoder_out_channels)
+    n_input_features = 2
     squeezer = Conv((1, 1), encoder_out_channels=>256, relu)
-    p1 = Conv((3, 3), (n_input_features * 256)=>256, relu; pad=1)
-    p2 = Conv((3, 3), 256=>256, relu; pad=1)
-    p3 = Conv((1, 1), 256=>(6 * n_predictions))
-    PoseDecoder(squeezer, p1, p2, p3, n_predictions)
+    pose = Chain(
+        Conv((3, 3), (n_input_features * 256)=>256, relu; pad=1),
+        Conv((3, 3), 256=>256, relu; pad=1),
+        Conv((1, 1), 256=>6))
+    PoseDecoder(squeezer, pose)
 end
 
 function (decoder::PoseDecoder)(features)
     squeezed = cat(map(decoder.squeezer, features)...; dims=3)
-    pose = mean(decoder.p3(decoder.p2(decoder.p1(squeezed))); dims=(1, 2))
-
-    shape = (6, decoder.n_predictions, size(pose, 4))
-    pose = eltype(pose)(1e-2) .* reshape(pose, shape)
+    pose = mean(decoder.pose(squeezed); dims=(1, 2))
+    pose = eltype(pose)(1e-2) .* reshape(pose, (6, 1, size(pose, 4)))
     pose[1:3, :, :], pose[4:6, :, :]
 end


### PR DESCRIPTION
- Compute auto loss once.
- Use reflection padding to improve disparity at borders.
- Refactor code to get rid of `xs` list.
- Move auto loss calculation outside of the training loop.